### PR TITLE
fixing bug preventing more than 2 stacked interpretations

### DIFF
--- a/pydrogen/pydrogen.py
+++ b/pydrogen/pydrogen.py
@@ -45,10 +45,16 @@ class SemanticError(Exception):
 # function definition.
 class Function():
     def __init__(self, func, cls, interpretation = None):
-        self._func = func
+        # we want to create the Function object with the original function to
+        # allow any other stacked interpretations to access it -- this means the
+        # interpretations will be independent of each other, but the final
+        # returned Function will have access to all the interpretations
         self._interpretations = {}
         if type(func) == Function:
-            self._interpretations = {k:func._interpretations[k] for k in func._interpretations}
+            self._interpretations.update(func._interpretations)
+            self._func = func._func
+        else:
+            self._func = func
         self._interpretations[cls.__class__.__name__] = interpretation
     def __getattr__(self, attr):
         if (attr in self._interpretations): # Alternative interpretations.


### PR DESCRIPTION
The source of the bug preventing more than 2 stacked interpretations: the second time a function is interpreted, it's a Function object that gets passed to create the new Function object (and is assigned to the new function's _func member), so the next time anything tries to reinterpret that function, it attempts to get the source code of a Function object and it fails. Not sure if this was intended behavior, but this fix ensures that _func is always an actual function.
